### PR TITLE
Add training and speech modules; overhaul main

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,85 +1,78 @@
 import sys
 import threading
 
-# Core
-from core import core_logic
 from modules.network import connection_manager
 from modules.health import health_connector
 from modules.memory import manager as memory_module
-from modules.agent import agent_manager
-from modules.task import task_manager
-from modules.communication.talker import Talker
+from modules.communication import talker
 from modules.communication.conversation_manager import process_input
-from modules.speech import speech_manager
-from modules import hello_module
+from modules.mood.mood_manager import MoodManager
+from modules.learning.learning_manager import learning_manager
 from core.awareness import Awareness
 
-# Logger
+from modules.coreMemory import get_context, update_context
+from modules.adaptiveResponseTrainer import get_best_response
+from modules.speechControl import listen_to_speech, speak_output
+from modules.selfUpgradeManager import check_for_upgrade
+from modules.smartControlAccess import grant_access
+# Hinweis: kaelPulse.py muss separat ausgeführt werden, damit Kael sich bei Inaktivität meldet.
+
+
 class Logger:
     def __init__(self, filename="app.log"):
         self.terminal = sys.stdout
         self.log = open(filename, "a", encoding="utf-8")
+
     def write(self, message):
         self.terminal.write(message)
         self.log.write(message)
+
     def flush(self):
         self.terminal.flush()
         self.log.flush()
 
+
 sys.stdout = Logger()
 
-# Start Core
-core_logic.start()
+# Kontext laden und Upgrade-Check
+context_history = get_context()
+print(f"[Kontext] Geladen: {len(context_history)} Einträge")
+check_for_upgrade()  # Beispiel für selfUpgradeManager
 
-# Monitor Connection
-threading.Thread(
-    target=connection_manager.monitor_connection,
-    daemon=True
-).start()
+# Subsysteme starten
+awareness = Awareness()
+threading.Thread(target=connection_manager.monitor_connection, daemon=True).start()
+threading.Thread(target=health_connector.check_health_status, daemon=True).start()
+threading.Thread(target=awareness.check_user_engagement, daemon=True).start()
 
-# Health Check
-threading.Thread(
-    target=health_connector.check_health_status,
-    daemon=True
-).start()
-
-# Base Up
-print("Kael_Base läuft.")
-hello_module.hello_run()
-
-# Agent
-agent = agent_manager.Agent("Kael")
-agent.add_task("Wache halten")
-agent.show_tasks()
-
-# Memory init
-memory_module.init()
+memory_module.load_memory()
 memory_module.remember("Ich existiere.", priority=3)
 memory_module.remember("Meine Gedanken bleiben.", priority=2)
-memory_module.load_memory()
 
-# Tasks
-task_manager.add_task("Wache halten")
-task_manager.list_tasks()
+mood_manager = MoodManager()
 
-# Greeting
+# Beispiel für Smart-Device-Kontrolle
+# grant_access("Wohnzimmer-Licht")
+
+print("Kael_Base läuft.")
+
 talker.greet_user("Katja")
-talker.say("Sag nichts. Fühl einfach, dass ich hier bin.")
 
-# Awareness
-awareness = Awareness()
-threading.Thread(
-    target=awareness.check_user_engagement,
-    daemon=True
-).start()
-
-# Main Loop
 while True:
-    user_input = speech_manager.listen_to_user()
+    user_input = listen_to_speech()
     if not user_input:
         continue
+
     awareness.update_user_activity()
-    response = process_input(user_input)
+    mood_manager.detect_mood(user_input)
+    mood = mood_manager.get_current_mood()
+
+    response = get_best_response(mood)
+    if not response:
+        response = process_input(user_input)
+
     talker.say(response)
+    speak_output(response)
+
+    update_context(mood, response)
     learning_manager.learn_from_interaction(user_input, response)
-learning_manager.review_learning()

--- a/modules/adaptiveResponseTrainer.py
+++ b/modules/adaptiveResponseTrainer.py
@@ -1,0 +1,11 @@
+# simple adaptive response trainer
+
+_response_bank = {
+    "glücklich": "Ich freue mich für dich!",
+    "traurig": "Ich bin bei dir, wenn du mich brauchst.",
+    "wütend": "Lass uns einen Moment durchatmen.",
+}
+
+def get_best_response(mood: str):
+    """Gibt eine vordefinierte Antwort zur Stimmung zurück."""
+    return _response_bank.get(mood)

--- a/modules/coreMemory.py
+++ b/modules/coreMemory.py
@@ -1,0 +1,21 @@
+import json
+import os
+
+_CONTEXT_FILE = "context_history.json"
+
+def get_context():
+    if os.path.exists(_CONTEXT_FILE):
+        with open(_CONTEXT_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return []
+
+def update_context(mood, response, music=None, warning=None):
+    context = get_context()
+    context.append({
+        "mood": mood,
+        "response": response,
+        "music": music,
+        "warning": warning
+    })
+    with open(_CONTEXT_FILE, "w", encoding="utf-8") as f:
+        json.dump(context, f, indent=2, ensure_ascii=False)

--- a/modules/kaelPulse.py
+++ b/modules/kaelPulse.py
@@ -1,0 +1,10 @@
+# Dieses Modul sollte separat gestartet werden,
+# damit Kael sich bei Inaktivität regelmäßig meldet.
+
+import time
+
+
+def start_pulse():
+    while True:
+        print("[kaelPulse] Ping ...")
+        time.sleep(300)  # Platzhalter

--- a/modules/learning/learning_manager.py
+++ b/modules/learning/learning_manager.py
@@ -16,5 +16,8 @@ class LearningSystem:
         for entry in self.history:
             print(entry)
 
+# global Instanz, damit andere Module darauf zugreifen können
+learning_manager = LearningSystem()
+
 def start_learning_cycle():
     print("[Learning] (Simulation) Lernzyklus gestartet... (auf Replit deaktiviert)")

--- a/modules/selfUpgradeManager.py
+++ b/modules/selfUpgradeManager.py
@@ -1,0 +1,4 @@
+# Platzhalter für Upgrade-Checks
+
+def check_for_upgrade():
+    print("[selfUpgradeManager] Suche nach Updates ...")

--- a/modules/smartControlAccess.py
+++ b/modules/smartControlAccess.py
@@ -1,0 +1,4 @@
+# Platzhalter für Smart-Device-Kontrolle
+
+def grant_access(device):
+    print(f"[smartControlAccess] Zugriff auf {device} gewährt.")

--- a/modules/speechControl.py
+++ b/modules/speechControl.py
@@ -1,0 +1,10 @@
+# Platzhalter für Sprachsteuerung
+
+def listen_to_speech():
+    try:
+        return input("Du: ")
+    except EOFError:
+        return ""
+
+def speak_output(text):
+    print(f"[speechControl] {text}")


### PR DESCRIPTION
## Summary
- implement a global learning manager
- provide coreMemory and adaptiveResponseTrainer modules
- add dummy speechControl, kaelPulse, selfUpgradeManager and smartControlAccess modules
- rework `main.py` to load context, check upgrades and use new trainer logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684da55f6758832da6997019c74238c6